### PR TITLE
Fix "warning: `&' interpreted as argument prefix"

### DIFF
--- a/lib/marcel/mime_type.rb
+++ b/lib/marcel/mime_type.rb
@@ -61,7 +61,7 @@ class Marcel::MimeType
       def with_io(pathname_or_io, &block)
         case pathname_or_io
         when Pathname
-          pathname_or_io.open &block
+          pathname_or_io.open(&block)
         else
           yield pathname_or_io
         end


### PR DESCRIPTION
This fixes following warning:

```
marcel-0.3.1/lib/marcel/mime_type.rb:64: warning: `&' interpreted as argument prefix
```