### PR TITLE
Require pathname to run tests without Bundler.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require 'marcel'
+require 'pathname'
 
 class Marcel::TestCase < MiniTest::Test
   class << self


### PR DESCRIPTION
Hi,
I am testing `marcel` on an environment without Bundler. 
Because I want to create the RPM package for Fedora Project (RPM based Linux distribution).

I guess that when the tests are run on this repository's Travis CI on Bundler, `require 'pathname'` is already called. We did not have to set `require 'pathname'`.

Is it possible to merge this PR considering the Fedora Project's testing environment?

```
[mockbuild@996fa908f74e421489be9f612f1caf8d marcel-0.3.2]$ ruby -Ilib:test -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
Traceback (most recent call last):
	12: from -e:1:in `<main>'
	11: from -e:1:in `glob'
	10: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:59:in `require'
	 9: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:59:in `require'
	 8: from /builddir/build/BUILD/marcel-0.3.2/usr/share/gems/gems/marcel-0.3.2/test/extension_test.rb:4:in `<top (required)>'
	 7: from /builddir/build/BUILD/marcel-0.3.2/usr/share/gems/gems/marcel-0.3.2/test/extension_test.rb:14:in `<class:ExtensionTest>'
	 6: from /builddir/build/BUILD/marcel-0.3.2/usr/share/gems/gems/marcel-0.3.2/test/test_helper.rb:30:in `each_content_type_fixture'
	 5: from /usr/share/ruby/fileutils.rb:122:in `cd'
	 4: from /usr/share/ruby/fileutils.rb:122:in `chdir'
	 3: from /builddir/build/BUILD/marcel-0.3.2/usr/share/gems/gems/marcel-0.3.2/test/test_helper.rb:31:in `block in each_content_type_fixture'
	 2: from /builddir/build/BUILD/marcel-0.3.2/usr/share/gems/gems/marcel-0.3.2/test/test_helper.rb:31:in `map'
	 1: from /builddir/build/BUILD/marcel-0.3.2/usr/share/gems/gems/marcel-0.3.2/test/test_helper.rb:35:in `block (2 levels) in each_content_type_fixture'
/builddir/build/BUILD/marcel-0.3.2/usr/share/gems/gems/marcel-0.3.2/test/test_helper.rb:26:in `files': uninitialized constant #<Class:Marcel::TestCase>::Pathname (NameError)
```

Thanks!