### PR TITLE
Suppress warnings when running "gem build marcel.gemspec"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     mimemagic (0.3.2)
-    minitest (5.10.2)
+    minitest (5.11.3)
     rack (2.0.3)
     rake (10.5.0)
 
@@ -18,8 +18,8 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.7)
   marcel!
-  minitest
-  rack (~> 2.0.1)
+  minitest (~> 5.11)
+  rack (~> 2.0)
   rake (~> 10.0)
 
 BUNDLED WITH

--- a/marcel.gemspec
+++ b/marcel.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'mimemagic', '~> 0.3.2'
 
-  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rack', '~> 2.0.1'
+  spec.add_development_dependency 'rack', '~> 2.0'
 end


### PR DESCRIPTION
* Suppress warnings when running "gem build marcel.gemspec".
* Typo filenames => file names.

Right now there are warnings, running `gem build marcel.gemspec`.
I fixed the warnings.
I also changed a small typo "filenames" to "file names" to use words in dictionary.

```
$ gem build marcel.gemspec
WARNING:  open-ended dependency on minitest (>= 0, development) is not recommended
  if minitest is semantically versioned, use:
    add_development_dependency 'minitest', '~> 0'
WARNING:  pessimistic dependency on rack (~> 2.0.1, development) may be overly strict
  if rack is semantically versioned, use:
    add_development_dependency 'rack', '~> 2.0', '>= 2.0.1'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: marcel
  Version: 0.3.2
  File: marcel-0.3.2.gem
```