### PR TITLE
Gemspec ignore test files for reduce gem size from 7.5MB to 7.5KB

### DIFF
--- a/marcel.gemspec
+++ b/marcel.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/basecamp/marcel'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = Dir['lib/**/*', 'MIT-LICENSE', 'README.md']
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
https://rubygems.org/gems/marcel

For reduce [ActiveStorage](https://github.com/basecamp/marcel/pull/11#issue-215745055) size

```diff
-- -rw-r--r--   1 jason  staff   7.5M  9 15 10:34 marcel-0.3.2.gem
++ -rw-r--r--   1 jason  staff   7.5K  9 15 10:45 marcel-0.3.2.gem
```

<img width="377" alt="2018-09-15 10 37 38" src="https://user-images.githubusercontent.com/5518/45581593-6fe9be80-b8d3-11e8-8ec1-f07b5f0420a9.png">