### PR TITLE
Don't require "pathname" stdlib to be loaded

### DIFF
--- a/lib/marcel/mime_type.rb
+++ b/lib/marcel/mime_type.rb
@@ -59,8 +59,7 @@ class Marcel::MimeType
       end
 
       def with_io(pathname_or_io, &block)
-        case pathname_or_io
-        when Pathname
+        if defined?(Pathname) && pathname_or_io.is_a?(Pathname)
           pathname_or_io.open(&block)
         else
           yield pathname_or_io


### PR DESCRIPTION
If the `pathname` standard library isn't required, then the `Pathname` constant will be missing. So we want to check first whether the constant exists before attempting to reference it, otherwise Marcel won't work properly without `pathname` being required.