### PR TITLE
Gemspec: Allow Bundler 2

### DIFF
--- a/marcel.gemspec
+++ b/marcel.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mimemagic', '~> 0.3.2'
 
   spec.add_development_dependency 'minitest', '~> 5.11'
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '>= 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rack', '~> 2.0'
 end


### PR DESCRIPTION
This PR loosens the development dependency for Bundler to also allow Bundler 2.
